### PR TITLE
Update dependencies

### DIFF
--- a/fpm.toml
+++ b/fpm.toml
@@ -6,7 +6,7 @@ maintainer = "damian@sourceryinstitute.org"
 copyright = "2021 Sourcery Institute"
 
 [dependencies]
-sourcery = {git = "https://github.com/sourceryinstitute/sourcery", tag = "21.02.24"}
+assert = {git = "https://github.com/sourceryinstitute/assert", tag = "1.3.0"}
 dag = {git = "https://github.com/sourceryinstitute/dag", tag = "2.0.1"}
 
 [dev-dependencies]

--- a/fpm.toml
+++ b/fpm.toml
@@ -7,7 +7,7 @@ copyright = "2021 Sourcery Institute"
 
 [dependencies]
 assert = {git = "https://github.com/sourceryinstitute/assert", tag = "1.3.0"}
-dag = {git = "https://github.com/sourceryinstitute/dag", tag = "2.0.1"}
+dag = {git = "https://github.com/sourceryinstitute/dag", tag = "2.1.0"}
 
 [dev-dependencies]
 vegetables = {git = "https://gitlab.com/everythingfunctional/vegetables", tag = "v7.0.2"}

--- a/src/application_s.f90
+++ b/src/application_s.f90
@@ -1,5 +1,5 @@
 submodule(application_m) application_s
-  use assertions_interface, only : assert
+  use assert_m, only : assert
   implicit none
 
 contains


### PR DESCRIPTION

This PR
    
1. Updates `fpm.toml` to use version 2.1.0 of the [Dag] dependency, which now features concurrent topological sorting and
2. Replaces [Sourcery] dependency with [Assert], which is the new location of the `assert` subroutine that has been from a recent version of [Sourcery].

[Dag]: https://github.com/sourceryinstitute/dag
[Sourcery]: https://github.com/sourceryinstitute/sourcery
[Assert]: https://github.com/sourceryinstitute/assert